### PR TITLE
[Ruby2.3] Object#timeout is deprecated, use Timeout.timeout instead.

### DIFF
--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -64,7 +64,7 @@ module Net; module SSH; module Transport
 
       debug { "establishing connection to #{@host}:#{@port}" }
       factory = options[:proxy] || TCPSocket
-      @socket = timeout(options[:timeout] || 0) {
+      @socket = ::Timeout.timeout(options[:timeout] || 0) {
         case
         when options[:proxy] then factory.open(@host, @port, options)
         when @bind_address.nil? then factory.open(@host, @port)
@@ -81,7 +81,7 @@ module Net; module SSH; module Transport
       @host_key_verifier = select_host_key_verifier(options[:paranoid])
 
 
-      @server_version = timeout(options[:timeout] || 0) { ServerVersion.new(socket, logger) }
+      @server_version = ::Timeout.timeout(options[:timeout] || 0) { ServerVersion.new(socket, logger) }
 
       @algorithms = Algorithms.new(self, options)
       wait { algorithms.initialized? }


### PR DESCRIPTION
- Try to fix this warning when using ruby2.3
```
net-ssh-2.9.4/lib/net/ssh/transport/session.rb:67:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
net-ssh-2.9.4/lib/net/ssh/transport/session.rb:84:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
```
- Use ::Timeout because net-ssh 2.9.4 include an exception class Net::SSH::Timeout 